### PR TITLE
Add Solana SDK Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [binance-futures-trading-bot](https://github.com/Erfaniaa/binance-futures-trading-bot) - Easy-to-use multi-strategic automatic trading for Binance Futures with Telegram integration
 * [Solie](https://github.com/cunarist/solie) - The ultimate trading bot designed for targeting the futures markets of Binance. It enables you to create and customize your own trading strategies, simulating them using real historical data from Binance with the power of Python.
 * [OpenTrader](https://github.com/bludnic/opentrader) - Self-hosted crypto trading bot featuring built-in strategies like GRID and DCA. Provides a UI for managing multiple bots, including paper trading and backtesting capabilities. Supports 100+ exchanges via CCXT.
+* [Solana SDK Tools](https://github.com/DebuggingMax/solana-sdk-tools) - TypeScript toolkit for Solana DEX trading with multi-platform scanner (Pump.fun, Raydium), anti-rug analysis, copy trading, and paper trading mode.
 
 ## Technical analysis libraries
 


### PR DESCRIPTION
Adding [Solana SDK Tools](https://github.com/DebuggingMax/solana-sdk-tools) - TypeScript toolkit for Solana DEX trading.

- Multi-DEX scanner (Pump.fun, Raydium, Moonshot)
- Anti-rug token analysis
- Copy trading & paper trading
- Docker support

npm: https://npmjs.com/package/solana-sdk-tools
MIT licensed.