### PR TITLE
Add NoxBaseBot - Telegram crypto trading bot for Base chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [binance-futures-trading-bot](https://github.com/Erfaniaa/binance-futures-trading-bot) - Easy-to-use multi-strategic automatic trading for Binance Futures with Telegram integration
 * [Solie](https://github.com/cunarist/solie) - The ultimate trading bot designed for targeting the futures markets of Binance. It enables you to create and customize your own trading strategies, simulating them using real historical data from Binance with the power of Python.
 * [OpenTrader](https://github.com/bludnic/opentrader) - Self-hosted crypto trading bot featuring built-in strategies like GRID and DCA. Provides a UI for managing multiple bots, including paper trading and backtesting capabilities. Supports 100+ exchanges via CCXT.
+* [NoxBaseBot](https://github.com/dayi1000/NoxBaseBot) - A Telegram crypto trading bot for Base chain with 23+ commands including real-time prices, portfolio tracking, PnL analysis, token comparison, whale alerts, gas monitoring, and trading signals. Built with Node.js and CoinGecko API. Try it: [@NoxBaseBot](https://t.me/NoxBaseBot).
 
 ## Technical analysis libraries
 


### PR DESCRIPTION
Adding [NoxBaseBot](https://t.me/NoxBaseBot), an open-source Telegram crypto trading bot focused on Base chain.

**Features (23+ commands):**
- Real-time prices for 30+ tokens via CoinGecko
- Portfolio tracking and PnL analysis
- Token comparison, whale alerts, gas monitoring
- Top gainers/losers, trending tokens, crypto news
- Multi-token calculator and converter
- Referral system for organic growth

**Tech:** Node.js, node-telegram-bot-api, CoinGecko API

**GitHub:** https://github.com/dayi1000/NoxBaseBot
**Try it:** https://t.me/NoxBaseBot