### PR TITLE
Add defi-mcp to API and data providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [CoinGecko API](https://www.coingecko.com/en/api) - Complete historic data since 2014. Free for all.
 * [CoinMarketCap API](https://coinmarketcap.com/api/) - Complete historic data since 2013. Free plan available.
 * [CryptoCompare API](https://min-api.cryptocompare.com/) - Real-time and historical data. Free plan available.
+* [defi-mcp](https://github.com/OzorOwn/defi-mcp) - Free MCP server for real-time crypto data — token prices, gas fees, DEX swap quotes, and wallet balances across 9 chains.
 * [FinancialData.Net](https://financialdata.net/) - Crypto information, real-time quotes, intraday and end-of-day data.
 * [DexScreener API](https://docs.dexscreener.com/api/reference) - Real-time DEX pairs, pools and token profiles API.
 * [NanoStack](https://github.com/nano-labs-io/nanostack-api) - Permissionless cross-chain execution API — 59 chains, 8-15 bps fees, real-time signal data with BLAKE3 proofs.


### PR DESCRIPTION
## Summary
Adds [defi-mcp](https://github.com/OzorOwn/defi-mcp) to the API and data providers section.

defi-mcp is a free, open-source MCP server providing real-time crypto data:
- Token prices for 8,000+ assets
- Gas fee tracking across 9 chains
- DEX swap quotes via Jupiter (Solana) and Uniswap
- Multi-chain wallet balance checks
- Trending token discovery

Free to use, open source on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)