### PR TITLE
Add Clawdia Crypto Feeds to API and data providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 ## API and data providers
 
 * [Bitquery](https://bitquery.io/) - Blockchain and DEX data APIs.
+* [Clawdia Crypto Feeds](https://api-catalog-three.vercel.app/tools/crypto-prices) - Free real-time price API for 500+ tokens. No API key required. Simple REST: `GET /api/prices` or `GET /api/price/BTC`.
 * [CoinAPI](https://www.coinapi.io/) - 308 exchanges integrated in a single API. Real-time and historical data.
 * [CoinCap API](https://docs.coincap.io/) - Real-time and historical data. Free for all.
 * [CoinGecko API](https://www.coingecko.com/en/api) - Complete historic data since 2014. Free for all.


### PR DESCRIPTION
Adds Clawdia Crypto Feeds API to the API and data providers section.

**What it is:** A free real-time cryptocurrency price API covering 500+ tokens. Returns JSON with current price, 24h change, market cap, and volume.

**Endpoints:**
- `GET /api/prices` — all 500+ tokens
- `GET /api/price/BTC` — individual token lookup

**Why it fits:**
- No API key required for basic queries (free tier: 50 req/day per IP)
- Clean JSON responses designed for trading bots and scripts
- Sub-100ms response times
- Also available via x402 micropayments for high-frequency usage

[Try the interactive demo](https://api-catalog-three.vercel.app/tools/crypto-prices)