### PR TITLE
Add VARRD - AI-powered trading edge discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [binance-futures-trading-bot](https://github.com/Erfaniaa/binance-futures-trading-bot) - Easy-to-use multi-strategic automatic trading for Binance Futures with Telegram integration
 * [Solie](https://github.com/cunarist/solie) - The ultimate trading bot designed for targeting the futures markets of Binance. It enables you to create and customize your own trading strategies, simulating them using real historical data from Binance with the power of Python.
 * [OpenTrader](https://github.com/bludnic/opentrader) - Self-hosted crypto trading bot featuring built-in strategies like GRID and DCA. Provides a UI for managing multiple bots, including paper trading and backtesting capabilities. Supports 100+ exchanges via CCXT.
+* [VARRD](https://github.com/augiemazza/varrd) - AI-powered trading edge discovery platform. Validates trading ideas with event studies, statistical tests, and real market data. Available as CLI, Python SDK, and MCP server.
 
 ## Technical analysis libraries
 


### PR DESCRIPTION
Adds [VARRD](https://github.com/augiemazza/varrd) to the Open source bots section.

VARRD validates trading ideas with statistical tests before you deploy them. Give it any idea in plain English, it loads real market data, runs event studies with proper controls (overfitting prevention, multiple testing correction, out-of-sample validation), and tells you if there's a real edge.

Available as a CLI (`pip install varrd`), Python SDK, and MCP server. Works alongside any trading bot as a pre-deployment validation layer.