### PR TITLE
Add Parsec to API and data providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [DexScreener API](https://docs.dexscreener.com/api/reference) - Real-time DEX pairs, pools and token profiles API.
 * [NanoStack](https://github.com/nano-labs-io/nanostack-api) - Permissionless cross-chain execution API — 59 chains, 8-15 bps fees, real-time signal data with BLAKE3 proofs.
 * [Nomics API](https://p.nomics.com/cryptocurrency-bitcoin-api) - Trades and orders, market data, market cap.
+* [Parsec](https://parsecapi.com/) - HFT-focused prediction market infrastructure for normalized data, execution, and live streams across Polymarket, Kalshi, Opinion, Limitless, and PredictFun. Generous free tier.
 * [shrimpy developers](https://developers.shrimpy.io/) - Real-time full order book data, limit orders, open orders, smart order routing, exchange account management, user management, and a complete cloud infrastructure solution right out of the box.
 * [Tradifull API](https://docs.tradifull.com/) - Direct access to exchanges tickers in a unified way, or to our calculated average prices, low, high, volumes, available in a lot of fiats/stable coins. Free for all.
 


### PR DESCRIPTION
Parsec is a unified prediction market API with execution across 5 venues. Normalized orderbooks, trades, WebSocket streams. Built in Rust for bot-friendly latency. Free tier: 10K requests/month.