### PR TITLE
Add polymarket-whales — real-time whale tracker for Polymarket

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 ## Market data libraries
 
 * [aio-kraken-ws](https://gitlab.com/cdlr75/aio-kraken-ws) - Python library on top of asyncio to stream market data from Kraken.
+- [polymarket-whales](https://github.com/al1enjesus/polymarket-whales) - Real-time whale trade tracker for Polymarket — fires alerts when large orders hit the book. Terminal + Telegram. Python, MIT, zero config.
 * [bitpanda-ws](https://github.com/IOfate/bitpanda-ws) - Node.js websocket client for BitPanda.
 * [kucoin-ws](https://github.com/IOfate/kucoin-ws) - Node.js websocket client for KuCoin.
 * [binance](https://github.com/tiagosiebler/binance) - A typed & heavily tested TypeScript/Node.js library for the Binance REST APIs and Websockets, available on npm, for the backend and the browser.


### PR DESCRIPTION
**[polymarket-whales](https://github.com/al1enjesus/polymarket-whales)** monitors the Polymarket CLOB order book for large trades and fires instant alerts — terminal output + optional Telegram notifications.

**Why it fits here:**
- It's a Python trading bot/tool specifically for Polymarket
- Monitors live order flow and alerts on whale-sized trades
- Zero config to run: `git clone` + `pip install` + `python main.py`
- MIT licensed, actively maintained

⭐ 100% open source, no API key required