### PR TITLE
Add SignalFuse Starter Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [binance-futures-trading-bot](https://github.com/Erfaniaa/binance-futures-trading-bot) - Easy-to-use multi-strategic automatic trading for Binance Futures with Telegram integration
 * [Solie](https://github.com/cunarist/solie) - The ultimate trading bot designed for targeting the futures markets of Binance. It enables you to create and customize your own trading strategies, simulating them using real historical data from Binance with the power of Python.
 * [OpenTrader](https://github.com/bludnic/opentrader) - Self-hosted crypto trading bot featuring built-in strategies like GRID and DCA. Provides a UI for managing multiple bots, including paper trading and backtesting capabilities. Supports 100+ exchanges via CCXT.
+* [SignalFuse Starter Bot](https://github.com/hypeprinter007-stack/signalfuse-starter-bot) - Hyperliquid trading bot powered by fused sentiment, regime, and market structure signals with x402 USDC micropayments.
 
 ## Technical analysis libraries
 


### PR DESCRIPTION
Adds [SignalFuse Starter Bot](https://github.com/hypeprinter007-stack/signalfuse-starter-bot) to the Open source bots section.

Hyperliquid trading bot that fuses sentiment, regime, and market structure signals with x402 USDC micropayments for signal access.