### PR TITLE
Add polymarket-agent-mcp to Open source bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [magic8bot](https://github.com/magic8bot/magic8bot) - Magic8bot is a cryptocurrency trading bot using Node.js and MongoDB.
 * [Octobot](https://github.com/Drakkar-Software/OctoBot) - Powerful fully modular open-source cryptocurrency trading bot with trading tools, a backtesting engine, an user interface, etc.
 * [Planar](https://github.com/psydyllic/Planar.jl) - Fast, flexible and featureful crypto trading bot (and framework) written in Julia, based on CCXT.
-* [Polymarket Trader MCP](https://github.com/demwick/polymarket-trader-mcp) - AI-powered MCP server for Polymarket prediction markets. 48 tools for trading, copy trading, smart money flow detection, backtesting, and portfolio management. Works with Claude, Cursor, or any MCP client.
+* [Polymarket Agent MCP](https://github.com/demwick/polymarket-agent-mcp) - AI-powered MCP server for Polymarket prediction markets. 48 tools for trading, copy trading, smart money flow detection, backtesting, and portfolio management. Works with Claude, Cursor, or any MCP client.
 * [QtBitcoinTrader](https://github.com/JulyIghor/QtBitcoinTrader) - Secure multi crypto exchange trading client. This software helps you open and cancel orders very fast. Real time data monitoring. Developed on pure Qt, uses OpenSSL, AES 256 key and secret protection.
 * [Superalgos](https://github.com/Superalgos/Superalgos) - Superalgos is open-source crypto trading bot who let you visually design your crypto trading bot, leveraging an integrated charting system, data-mining, backtesting, paper trading, and multi-server crypto bot deployments.
 * [WolfBot](https://github.com/Ekliptor/WolfBot) - Crypto currency trading bot written in TypeScript for Node.js.
@@ -130,4 +130,3 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 Experience the **ultimate trading bot marketplace** and online **crypto trading bot builder** with **simplicity** with [Kryll](https://kryll.io?ref=botcrypto).
 
 [![banner](https://github.com/botcrypto-io/awesome-crypto-trading-bots/assets/10849491/94efbecc-df2a-454e-aa71-acad0237a868)](https://kryll.io?ref=botcrypto)
-

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [magic8bot](https://github.com/magic8bot/magic8bot) - Magic8bot is a cryptocurrency trading bot using Node.js and MongoDB.
 * [Octobot](https://github.com/Drakkar-Software/OctoBot) - Powerful fully modular open-source cryptocurrency trading bot with trading tools, a backtesting engine, an user interface, etc.
 * [Planar](https://github.com/psydyllic/Planar.jl) - Fast, flexible and featureful crypto trading bot (and framework) written in Julia, based on CCXT.
+* [Polymarket Trader MCP](https://github.com/demwick/polymarket-trader-mcp) - AI-powered MCP server for Polymarket prediction markets. 48 tools for trading, copy trading, smart money flow detection, backtesting, and portfolio management. Works with Claude, Cursor, or any MCP client.
 * [QtBitcoinTrader](https://github.com/JulyIghor/QtBitcoinTrader) - Secure multi crypto exchange trading client. This software helps you open and cancel orders very fast. Real time data monitoring. Developed on pure Qt, uses OpenSSL, AES 256 key and secret protection.
 * [Superalgos](https://github.com/Superalgos/Superalgos) - Superalgos is open-source crypto trading bot who let you visually design your crypto trading bot, leveraging an integrated charting system, data-mining, backtesting, paper trading, and multi-server crypto bot deployments.
 * [WolfBot](https://github.com/Ekliptor/WolfBot) - Crypto currency trading bot written in TypeScript for Node.js.


### PR DESCRIPTION
Adds [polymarket-agent-mcp](https://github.com/demwick/polymarket-agent-mcp) to the Open source bots section.

AI-powered MCP server for Polymarket prediction markets — 48 tools for trading, copy trading, smart money flow detection, backtesting, and portfolio management.

- GitHub: [demwick/polymarket-agent-mcp](https://github.com/demwick/polymarket-agent-mcp)
- npm: [polymarket-agent-mcp](https://www.npmjs.com/package/polymarket-agent-mcp)
- TypeScript, MIT license, 205+ tests