### PR TITLE
Add DeepAlpha - AI-powered trading bot for Hyperliquid

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [binance-futures-trading-bot](https://github.com/Erfaniaa/binance-futures-trading-bot) - Easy-to-use multi-strategic automatic trading for Binance Futures with Telegram integration
 * [Solie](https://github.com/cunarist/solie) - The ultimate trading bot designed for targeting the futures markets of Binance. It enables you to create and customize your own trading strategies, simulating them using real historical data from Binance with the power of Python.
 * [OpenTrader](https://github.com/bludnic/opentrader) - Self-hosted crypto trading bot featuring built-in strategies like GRID and DCA. Provides a UI for managing multiple bots, including paper trading and backtesting capabilities. Supports 100+ exchanges via CCXT.
+* [DeepAlpha](https://github.com/stefanoviana/deepalpha) - AI-powered autonomous trading bot for Hyperliquid DEX. Uses LightGBM + XGBoost ensemble with 40 features, walk-forward validation, and self-learning from own trades. Trades all 229 perpetual markets with maker-only orders for zero fees.
 
 ## Technical analysis libraries
 
@@ -129,4 +130,3 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 Experience the **ultimate trading bot marketplace** and online **crypto trading bot builder** with **simplicity** with [Kryll](https://kryll.io?ref=botcrypto).
 
 [![banner](https://github.com/botcrypto-io/awesome-crypto-trading-bots/assets/10849491/94efbecc-df2a-454e-aa71-acad0237a868)](https://kryll.io?ref=botcrypto)
-


### PR DESCRIPTION
## Add DeepAlpha

Hi! I'd like to add [DeepAlpha](https://github.com/stefanoviana/deepalpha) to the **Open source bots** section.

### What is DeepAlpha?

DeepAlpha is an open-source, AI-powered autonomous trading bot built specifically for [Hyperliquid](https://hyperliquid.xyz) DEX. Key features:

- **ML Ensemble**: LightGBM + XGBoost ensemble model with 40 engineered features
- **Walk-Forward Validation**: Prevents overfitting with rolling train/test splits
- **Self-Learning**: Continuously learns from its own trade outcomes to improve predictions
- **Full Market Coverage**: Trades all 229 perpetual markets on Hyperliquid
- **Zero Fees**: Uses maker-only orders to take advantage of Hyperliquid's 0% maker fee
- **Risk Management**: Position sizing, drawdown limits, and correlation-aware portfolio management

The project is actively maintained, fully open source (MIT license), and written in Python.

### Checklist
- [x] Open source project
- [x] Active development
- [x] Crypto trading bot
- [x] Follows list format