### PR TITLE
Add Microverse Systems market data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [CryptoCompare API](https://min-api.cryptocompare.com/) - Real-time and historical data. Free plan available.
 * [FinancialData.Net](https://financialdata.net/) - Crypto information, real-time quotes, intraday and end-of-day data.
 * [DexScreener API](https://docs.dexscreener.com/api/reference) - Real-time DEX pairs, pools and token profiles API.
+* [Microverse Systems](https://microversesystems.com) - Free real-time L2 order book data from 21 exchanges. WebSocket API, no key required.
 * [NanoStack](https://github.com/nano-labs-io/nanostack-api) - Permissionless cross-chain execution API — 59 chains, 8-15 bps fees, real-time signal data with BLAKE3 proofs.
 * [Nomics API](https://p.nomics.com/cryptocurrency-bitcoin-api) - Trades and orders, market data, market cap.
 * [shrimpy developers](https://developers.shrimpy.io/) - Real-time full order book data, limit orders, open orders, smart order routing, exchange account management, user management, and a complete cloud infrastructure solution right out of the box.


### PR DESCRIPTION
## Summary
- Adds [Microverse Systems](https://microversesystems.com) to the **API and data providers** section
- Free real-time L2 order book data from 21 exchanges via WebSocket API, no key required
- Entry placed in alphabetical order

## Test plan
- [ ] Verify the link resolves correctly
- [ ] Confirm alphabetical ordering in the API and data providers section

🤖 Generated with [Claude Code](https://claude.com/claude-code)