### PR TITLE
Add cipher-starter solo Solana bot playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [financial-dataset-generator](https://github.com/Erfaniaa/financial-dataset-generator) - Easy-to-use dataset generator for applying machine learning on financial markets
 * [undervalued-crypto-finder](https://github.com/Erfaniaa/undervalued-crypto-finder) - Get a list of cryptocurrencies which are now cheap and may be a good opportunity for investment. This project finds some cryptocurrencies which are below the daily moving average (eg. MA200).
 * [Gunbot Quant](https://github.com/GuntharDeNiro/gunbot-quant) - Standalone application for market screening and backtesting, focus on screening with algo trading in mind, offers repeatable workflows and useful, beautiful reports.
+* [Crypto Motifs cipher-starter](https://github.com/cryptomotifs/cipher-starter) - 150-page playbook for building a Solana-native signal engine + autonomous trading bot solo on $0/mo infra. Covers MEV sandwich defenses (Jito bundles + oracle gates), three-tier wallet architecture, eighth-Kelly sizing, and a 30-day paper-trade gate. [Landing](https://cryptomotifs.github.io/cipher-starter/).
 
 ## Development Communities
 ### Telegram


### PR DESCRIPTION
Adding **Crypto Motifs / cipher-starter** to **Miscellaneous tools**.

A 150-page open research bundle (MIT) for solo devs building a Solana-native signal engine + autonomous trading bot on $0/mo infrastructure.

12 playbooks covering: trading universe + top-K signal filtering, eighth-Kelly sizing, 5-breaker risk rails, three-tier wallet architecture ($100 hot / $300 warm / $600 cold) with KMS envelope + isolated signer subprocess, MEV sandwich defenses via Jito bundles + oracle gates, Canadian NI 31-103 compliance memo, Oracle Cloud Always Free deploy blueprint, and a ~1000-tool audit with 30 P0 picks.

- Repo: https://github.com/cryptomotifs/cipher-starter
- Landing: https://cryptomotifs.github.io/cipher-starter/

Happy to reposition to another section if a better fit exists.
