### PR TITLE
Add BitBank to API and data providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 
 ## API and data providers
 
+* [BitBank](https://bitbank.nz) - AI-powered crypto forecasting and predictions API with machine learning models.
 * [Bitquery](https://bitquery.io/) - Blockchain and DEX data APIs.
 * [CoinAPI](https://www.coinapi.io/) - 308 exchanges integrated in a single API. Real-time and historical data.
 * [CoinCap API](https://docs.coincap.io/) - Real-time and historical data. Free for all.


### PR DESCRIPTION
## Summary
- Adds [BitBank](https://bitbank.nz) to the **API and data providers** section
- BitBank is an AI-powered crypto forecasting and predictions API with machine learning models
- Entry placed in alphabetical order within the section, matching existing formatting convention

## Test plan
- [ ] Verify the link to bitbank.nz is accessible
- [ ] Confirm formatting matches existing entries in the API and data providers section