### PR TITLE
Add Hive Intelligence (crypto market infrastructure for AI agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [CryptoCompare API](https://min-api.cryptocompare.com/) - Real-time and historical data. Free plan available.
 * [FinancialData.Net](https://financialdata.net/) - Crypto information, real-time quotes, intraday and end-of-day data.
 * [DexScreener API](https://docs.dexscreener.com/api/reference) - Real-time DEX pairs, pools and token profiles API.
+* [Hive Intelligence](https://github.com/hive-intel/hive-crypto-mcp) - Institutional-grade crypto market infrastructure for AI — live prices, DeFi, wallets, and token risk across every major chain through a managed MCP, REST API, or CLI.
 * [NanoStack](https://github.com/nano-labs-io/nanostack-api) - Permissionless cross-chain execution API — 59 chains, 8-15 bps fees, real-time signal data with BLAKE3 proofs.
 * [Nomics API](https://p.nomics.com/cryptocurrency-bitcoin-api) - Trades and orders, market data, market cap.
 * [shrimpy developers](https://developers.shrimpy.io/) - Real-time full order book data, limit orders, open orders, smart order routing, exchange account management, user management, and a complete cloud infrastructure solution right out of the box.


### PR DESCRIPTION
Adds [Hive Intelligence](https://github.com/hive-intel/hive-crypto-mcp) to the **API and data providers** section.

**What Hive is:** institutional-grade crypto market infrastructure for AI — a managed MCP server, REST API, and CLI that connect AI agents to live crypto prices, DeFi activity, wallet positions, and token risk across every major chain. Hundreds of normalized tools across 14 category-scoped endpoints. Works with Claude Desktop, Claude Code, Cursor, ChatGPT Desktop, Windsurf, VS Code (GitHub Copilot Chat), Gemini CLI, and any MCP-compatible client.

**Why API and data providers fits:** This section lists crypto market-data APIs used to build trading bots (Bitquery, CoinAPI, CoinGecko, CoinMarketCap, CryptoCompare, DexScreener, etc.). Hive is the same category — it's a unified API for CEX + DEX market data plus wallet/DeFi/risk signals — and is directly usable by bots via MCP, REST, or CLI. Inserted alphabetically between `DexScreener API` and `NanoStack`. Entry uses the section's `* [Name](url) - description` format.
