### PR TITLE
Add Sharpe Rug Check API to API and data providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [DexScreener API](https://docs.dexscreener.com/api/reference) - Real-time DEX pairs, pools and token profiles API.
 * [NanoStack](https://github.com/nano-labs-io/nanostack-api) - Permissionless cross-chain execution API — 59 chains, 8-15 bps fees, real-time signal data with BLAKE3 proofs.
 * [Nomics API](https://p.nomics.com/cryptocurrency-bitcoin-api) - Trades and orders, market data, market cap.
+* [Sharpe Rug Check API](https://www.sharpe.ai/rug-check) - Free token safety and rug-check REST API for Solana (SPL + Token-2022) and EVM chains. 0-100 risk score with honeypot simulation, mint-authority, LP-lock, and holder-concentration checks. Useful for pre-trade safety gating in bots.
 * [shrimpy developers](https://developers.shrimpy.io/) - Real-time full order book data, limit orders, open orders, smart order routing, exchange account management, user management, and a complete cloud infrastructure solution right out of the box.
 * [Tradifull API](https://docs.tradifull.com/) - Direct access to exchanges tickers in a unified way, or to our calculated average prices, low, high, volumes, available in a lot of fiats/stable coins. Free for all.
 


### PR DESCRIPTION
Adding [Sharpe Rug Check API](https://www.sharpe.ai/rug-check) to the API and data providers list.

Free token safety / rug-check REST API — useful for pre-trade safety gating in trading bots:
- 6 chains: Solana (SPL + Token-2022), Ethereum, Base, BSC, Arbitrum, Polygon
- Returns 0-100 risk score plus explicit findings: honeypot sim, mint-authority, LP-lock status, holder concentration
- Low-latency, no signup, no rate-limit account required

Inserted alphabetically between Nomics API and shrimpy developers, matching the existing asterisk-bullet format.

Live: https://www.sharpe.ai/rug-check