### PR TITLE
Add Korra to Miscellaneous tools — markets analyst, execution gated on licensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [financial-dataset-generator](https://github.com/Erfaniaa/financial-dataset-generator) - Easy-to-use dataset generator for applying machine learning on financial markets
 * [undervalued-crypto-finder](https://github.com/Erfaniaa/undervalued-crypto-finder) - Get a list of cryptocurrencies which are now cheap and may be a good opportunity for investment. This project finds some cryptocurrencies which are below the daily moving average (eg. MA200).
 * [Gunbot Quant](https://github.com/GuntharDeNiro/gunbot-quant) - Standalone application for market screening and backtesting, focus on screening with algo trading in mind, offers repeatable workflows and useful, beautiful reports.
+* [Korra](https://korra.finance/groups) - Closed-source AI markets analyst that lives in your Telegram group as a member. Multi-domain market reads (macro, on-chain, news, sentiment) with per-group personality dials. Information mode only today; execution capability is on the roadmap gated on regulatory licensing (CIF in progress). Built by an ex-eToro Senior Market Analyst (CySEC Advanced). Free during early access.
 
 ## Development Communities
 ### Telegram


### PR DESCRIPTION
Adds Korra under **Miscellaneous tools** with an honest framing — happy to revise or close if it's the wrong category for this list.

### Important caveats up front

- **Closed-source.** Korra is a SaaS product, not an open-source repo like most of the existing entries.
- **Does not execute trades today.** Korra runs in information mode — descriptive about markets, never prescriptive about user holdings. Members and admins get analysis, not orders.
- **Execution capability is on the roadmap, gated on regulatory licensing.** Quantum Economics (the parent firm) is working toward a CIF (MiFID II / MiCA-compliant) authorization before adding any prescriptive / execution surface area. Until then, Korra is strictly an analyst.

### Why she might still fit this list

For traders who use bots, Korra fills the **research / signal-context / synthesis** half of the workflow — the part that informs which bots to run, which markets to focus on, when conditions are unusual. Multi-domain (macro releases, on-chain whale flows, news, social sentiment) in one voice; multi-channel (Telegram groups, web chat, Twitter, email).

### Background

Built by Mati Greenspan — 7.5-year Senior Market Analyst at eToro, CySEC Advanced certified. Currently running in three live Telegram groups, four months in production. Free during early access.

### Links

- Bot: https://t.me/KorraAI_bot
- Web: https://korra.finance/groups
- Founder: https://twitter.com/MatiGreenspan

Happy to close this if you'd rather keep the list focused on execution-capable bots — won't push back. Wanted to put it in front of you with the caveats visible so you can make the call.