### PR TITLE
Add dgbit to Open source bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [Cassandre](https://github.com/cassandre-tech/cassandre-trading-bot) -  Cassandre makes it easy to create and run a Java crypto trading bot. Cassandre takes care of exchange connections, accounts, orders, and position management.
 * [crypto-trading-bot](https://github.com/Haehnchen/crypto-trading-bot) - Crypto trading bot in Node.js for Bitfinex, Bitmex, and Binance.
 * [CryptoSignal](https://github.com/CryptoSignal/Crypto-Signal) - Crypto trading bot in python for Bittrex, Binance, Bittrex, Bitfinex, Coinbase, etc.
+* [dgbit](https://github.com/cryptuon/dgbit) - Professional Algorithmic Trading Framework for Bybit; Python, with backtesting, high-frequency strategies, Docker support, and a full exchange-API wrapper.
 * [fast-trade](https://github.com/jrmeier/fast-trade) - Backtesting library utilizing pandas and technical analysis indicator, built with strategy portability and performance in mind for back-test trading strategies.
 * [freqtrade](https://github.com/freqtrade/freqtrade) - Freqtrade is a free and open source crypto trading bot written in Python. It is designed to support all major exchanges and be controlled via Telegram. It contains backtesting, plotting and money management tools as well as strategy optimization by machine learning.
 * [Frostybot-JS](https://github.com/JulienPlanchetCoineo/frostybot-js) - Frostybot-JS is a cryptocurrency trading API endpoint designed to execute webhooks as orders on an exchange


### PR DESCRIPTION
## Summary
- Add [dgbit](https://github.com/cryptuon/dgbit) to the **Open source bots** section.

## About dgbit
dgbit is a professional algorithmic trading framework for the Bybit exchange. It is Python-based, includes a backtesting engine, supports high-frequency strategies, ships with Docker support, and wraps the Bybit exchange API.

- License: MIT
- Repo: https://github.com/cryptuon/dgbit
- Topics: bybit, python, backtesting, high-frequency, algorithmic-trading, cryptocurrency, docker, exchange-api, trading-bot