### PR TITLE
feat: add TWZRD Agent Intel to API and data providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [Nomics API](https://p.nomics.com/cryptocurrency-bitcoin-api) - Trades and orders, market data, market cap.
 * [shrimpy developers](https://developers.shrimpy.io/) - Real-time full order book data, limit orders, open orders, smart order routing, exchange account management, user management, and a complete cloud infrastructure solution right out of the box.
 * [Tradifull API](https://docs.tradifull.com/) - Direct access to exchanges tickers in a unified way, or to our calculated average prices, low, high, volumes, available in a lot of fiats/stable coins. Free for all.
+* [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring and signed receipts for Solana AI agent wallets. Verify agent identity before x402 micropayments. MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 ## Charting libraries
 


### PR DESCRIPTION
## What

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **API and data providers** section.

## Why

TWZRD Agent Intel provides trust scoring and signed receipts for Solana AI agent wallets — useful for trading bots that need to verify agent identity before making x402 micropayments. Tools: `score_agent(wallet)`, `preflight_check(wallet)` (free), `get_trust_receipt(wallet)` (paid HTTP 402). Available as an MCP server: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`.