### PR TITLE
Add The Stall — 210 pay-per-call MCP crypto data capabilities (x402, USDC on Base)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [Nomics API](https://p.nomics.com/cryptocurrency-bitcoin-api) - Trades and orders, market data, market cap.
 * [shrimpy developers](https://developers.shrimpy.io/) - Real-time full order book data, limit orders, open orders, smart order routing, exchange account management, user management, and a complete cloud infrastructure solution right out of the box.
 * [Tradifull API](https://docs.tradifull.com/) - Direct access to exchanges tickers in a unified way, or to our calculated average prices, low, high, volumes, available in a lot of fiats/stable coins. Free for all.
+* [The Stall](https://the-stall.intuitek.ai) - 173 pay-per-call capabilities via MCP: crypto prices, DeFi analytics, token security, Polymarket prediction markets, and on-chain intelligence. USDC on Base. No API key required. [GitHub](https://github.com/thebrierfox/the-stall)
 
 ## Charting libraries
 


### PR DESCRIPTION
## What

Adds [The Stall](https://the-stall.intuitek.ai) to the **API and data providers** section.

## What it is

The Stall is a live MCP server with 210 pay-per-call capabilities for crypto trading bots:

- **Crypto prices**: CEX & DEX prices across major exchanges
- **DeFi analytics**: liquidity pools, yield rates, protocol TVL
- **Token security**: contract risk scoring, honeypot detection, holder analysis
- **On-chain intelligence**: address profiling, transaction history, DeFi exposure  
- **Prediction markets**: Polymarket data (prices, positions, volume, resolution)
- **Sanctions screening**: OFAC/SDN checks for compliance

Protocol: x402 — bots pay per call in USDC on Base mainnet. No API key required.

## Links
- Live: https://the-stall.intuitek.ai
- MCP endpoint: https://the-stall.intuitek.ai/mcp
- GitHub: https://github.com/thebrierfox/the-stall
- Smithery: https://smithery.ai/server/thebrierfox/the-stall
