### PR TITLE
Add VERY-Basic-Bitcoin-Coinbase-Bot to Open source bots

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [binance-futures-trading-bot](https://github.com/Erfaniaa/binance-futures-trading-bot) - Easy-to-use multi-strategic automatic trading for Binance Futures with Telegram integration
 * [Solie](https://github.com/cunarist/solie) - The ultimate trading bot designed for targeting the futures markets of Binance. It enables you to create and customize your own trading strategies, simulating them using real historical data from Binance with the power of Python.
 * [OpenTrader](https://github.com/bludnic/opentrader) - Self-hosted crypto trading bot featuring built-in strategies like GRID and DCA. Provides a UI for managing multiple bots, including paper trading and backtesting capabilities. Supports 100+ exchanges via CCXT.
+* [VERY-Basic-Bitcoin-Coinbase-Bot](https://github.com/tg12/VERY-Basic-Bitcoin-Coinbase-Bot) - Lightweight Python bot that places small automated Bitcoin trades on Coinbase to capture incremental profits.
 
 ## Technical analysis libraries
 


### PR DESCRIPTION
Adds **VERY-Basic-Bitcoin-Coinbase-Bot** to Open source bots.

A lightweight Python bot that places small automated Bitcoin trades on Coinbase to generate incremental profits — simple, self-hosted, and easy to run.

Source: https://github.com/tg12/VERY-Basic-Bitcoin-Coinbase-Bot
