### PR TITLE
Add Adanos Market Sentiment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 
 ## API and data providers
 
+* [Adanos](https://adanos.org/) - Crypto market sentiment API using Reddit, news, and Polymarket signals for trading tools.
 * [Bitquery](https://bitquery.io/) - Blockchain and DEX data APIs.
 * [CoinAPI](https://www.coinapi.io/) - 308 exchanges integrated in a single API. Real-time and historical data.
 * [CoinCap API](https://docs.coincap.io/) - Real-time and historical data. Free for all.


### PR DESCRIPTION
## Summary
- add Adanos to the API and data providers section
- link directly to https://adanos.org/

## Fit
Adanos provides crypto market sentiment data from Reddit, news, and Polymarket signals for trading tools and bots.

## Checks
- git diff --check
- npx --yes awesome-lint README.md (reports existing upstream issues; the added Adanos row is not flagged)