### PR TITLE
Add RugLens to Miscellaneous tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [financial-dataset-generator](https://github.com/Erfaniaa/financial-dataset-generator) - Easy-to-use dataset generator for applying machine learning on financial markets
 * [undervalued-crypto-finder](https://github.com/Erfaniaa/undervalued-crypto-finder) - Get a list of cryptocurrencies which are now cheap and may be a good opportunity for investment. This project finds some cryptocurrencies which are below the daily moving average (eg. MA200).
 * [Gunbot Quant](https://github.com/GuntharDeNiro/gunbot-quant) - Standalone application for market screening and backtesting, focus on screening with algo trading in mind, offers repeatable workflows and useful, beautiful reports.
+* [RugLens](https://github.com/mrvlyouknowwho/ruglens) - Telegram bot that screens EVM tokens and TON jettons for rug-pull and honeypot risk (GoPlus data + on-chain sell simulation) before you trade them.
 
 ## Development Communities
 ### Telegram


### PR DESCRIPTION
Adds [RugLens](https://github.com/mrvlyouknowwho/ruglens) — an open-source (MIT) Telegram bot that screens EVM tokens (ETH/BSC/Base/Arbitrum/Polygon/Optimism/Avalanche) and TON jettons for rug-pull and honeypot risk: contract flags via GoPlus, on-chain sell simulation via honeypot.is, liquidity/holder data. Useful as a pre-trade safety check alongside trading bots. Live instance: [@RugLens_bot](https://t.me/RugLens_bot).