### PR TITLE
Add perpsignal to Technical analysis libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 
 * [catalyst](https://github.com/enigmampc/catalyst) - DEPRECATED - An algorithmic trading library for crypto-assets written in Python.
 * [finta](https://github.com/peerchemist/finta) - Common financial technical indicators implemented in Pandas.
+* [perpsignal](https://github.com/mokshyaprotocol/signalview) - A Pandas-based signal engine for perpetual futures: compose indicators into a strategy expression, then backtest it into Sharpe, return, drawdown and win rate with fees, funding, stops and leverage modelled.
 * [stocklook](https://github.com/zbarge/stocklook) - A crypto currency library for trading & market making bots, account management, and data analysis.
 * [ta](https://github.com/bukosabino/ta) - A Technical Analysis library useful to do feature engineering from financial time series datasets (Open, Close, High, Low, Volume) built on Pandas and Numpy.
 * [ta-lib](https://github.com/mrjbq7/ta-lib) - A widely used library by trading software developers requiring to perform technical analysis of financial market data.


### PR DESCRIPTION
Adds **perpsignal** to *Technical analysis libraries*, inserted alphabetically between `finta` and `stocklook`.

It is a Pandas-based signal engine for perpetual futures: you compose indicators into a strategy expression (or a JSON signal definition), then backtest it into Sharpe, return, drawdown and win rate with **fees, funding, stops/targets and leverage modelled**. Funding is the piece most backtesters skip, and on a multi-day perp position it is usually the cost that decides the outcome.

- Repo: https://github.com/mokshyaprotocol/signalview
- `pip install perpsignal` · Python 3.10+ · Apache-2.0
- CI runs the tests plus a real backtest on every push
- No wallet, key, custody or live-trading code — pure research library

I put it under *Technical analysis libraries* rather than *Open source bots* because it is a library, not a runnable bot. If *Market data libraries* or another section is a better fit, happy to move it.

Disclosure: I maintain the project. It is the extracted open-source core of a perps platform and works standalone with no account or signup.