### PR TITLE
Add Codex to API and data providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 ## API and data providers
 
 * [Bitquery](https://bitquery.io/) - Blockchain and DEX data APIs.
+* [Codex API](https://www.codex.io/) - Real-time and historical token prices, charts and holder data across 80+ networks. Free plan available.
 * [CoinAPI](https://www.coinapi.io/) - 308 exchanges integrated in a single API. Real-time and historical data.
 * [CoinCap API](https://docs.coincap.io/) - Real-time and historical data. Free for all.
 * [CoinGecko API](https://www.coingecko.com/en/api) - Complete historic data since 2014. Free for all.


### PR DESCRIPTION
- Add Codex to the API and data providers section: real-time and historical token prices, charts and holder data across 80+ networks