### PR TITLE
Add keel — auditable Shariah-compliance engine for spot crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Create **trading bots** and follow **smart investors** with [Coinrule](https://c
 * [jesse](https://github.com/jesse-ai/jesse) - Jesse is an advanced crypto trading framework which aims to simplify researching and defining trading strategies.
 * [K](https://github.com/ctubio/Krypto-trading-bot) - K is a very low latency market making trading bot with a fully featured web interface. It can place and cancel orders on one of several supported cryptocoin exchanges in less than a few miliseconds per order on a decent machine.
 * [Kelp](https://github.com/stellar/kelp) - Kelp is a free and open-source market making bot for the Stellar universal marketplace and for centralized exchanges such as Binance, Kraken, CoinbasePro, etc.
+* [keel](https://github.com/CodeGateSoftware/keel) - Auditable Shariah-compliance engine for spot crypto trading: attested fail-closed asset screening, AAOIFI §65.4 qabd enforcement and purification accounting, with a reference auto-trading agent for Coinbase.
 * [magic8bot](https://github.com/magic8bot/magic8bot) - Magic8bot is a cryptocurrency trading bot using Node.js and MongoDB.
 * [Octobot](https://github.com/Drakkar-Software/OctoBot) - Powerful fully modular open-source cryptocurrency trading bot with trading tools, a backtesting engine, an user interface, etc.
 * [Planar](https://github.com/psydyllic/Planar.jl) - Fast, flexible and featureful crypto trading bot (and framework) written in Julia, based on CCXT.


### PR DESCRIPTION
Adds [keel](https://github.com/CodeGateSoftware/keel) under **Open source bots** (alphabetical, after Kelp).

**Disclosure, in the project's own spirit:** I am the maintainer of keel. It is an Apache-2.0 Python engine — not a general bot framework: deterministic Shariah-compliance rails (attested fail-closed screening, AAOIFI §65.4 qabd as an executable check, purification accounting) with a reference auto-trading agent for Coinbase on top. Self-hosted, no cloud service, no paid tier. Site: [keeltrading.com](https://keeltrading.com).

If the fit or wording isn't right, happy to adjust or withdraw — the list's curation is the owner's call.