### PR TITLE
Add FillBench (reproducible exchange API latency + cost-to-trade benchmarks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Production-grade Rust-native trading engine with deterministic event-driven arch
 * [CoinMarketCap API](https://coinmarketcap.com/api/) - Complete historic data since 2013. Free plan available.
 * [CryptoCompare API](https://min-api.cryptocompare.com/) - Real-time and historical data. Free plan available.
 * [FinancialData.Net](https://financialdata.net/) - Crypto information, real-time quotes, intraday and end-of-day data.
+* [FillBench](https://fillbench.com) - Reproducible benchmarks for crypto exchange REST API latency (p50/p95/p99, TLS connect time) and true cost to trade (taker fee + measured spread + slippage), re-measured every 2h from a fixed US-East host. Open JSON + CC BY 4.0 data.
 * [DexPaprika API](https://api.dexpaprika.com) - Free DEX data across 34 blockchains. 30M+ pools, 27M+ tokens, real-time SSE streaming, OHLCV. No API key, no rate limits.
 * [DexScreener API](https://docs.dexscreener.com/api/reference) - Real-time DEX pairs, pools and token profiles API.
 * [NanoStack](https://github.com/nano-labs-io/nanostack-api) - Permissionless cross-chain execution API — 59 chains, 8-15 bps fees, real-time signal data with BLAKE3 proofs.


### PR DESCRIPTION
Adds FillBench under API and data providers: an independent, reproducible benchmark of crypto exchange REST API latency and true cost to trade, re-measured every 2 hours from a fixed US-East host, with open JSON and a public CC BY 4.0 data mirror.