### PR TITLE
Add Horus Flow to API and data providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Production-grade Rust-native trading engine with deterministic event-driven arch
 * [FinancialData.Net](https://financialdata.net/) - Crypto information, real-time quotes, intraday and end-of-day data.
 * [DexPaprika API](https://api.dexpaprika.com) - Free DEX data across 34 blockchains. 30M+ pools, 27M+ tokens, real-time SSE streaming, OHLCV. No API key, no rate limits.
 * [DexScreener API](https://docs.dexscreener.com/api/reference) - Real-time DEX pairs, pools and token profiles API.
+* [Horus Flow](https://github.com/horustechltd/horus-flow-mcp) - Institutional-grade L2 orderbook microstructure physics, whale spoofing detection, and Level 4 Cortex cognitive brain for autonomous trading bots and AI agents. Free tier available.
 * [NanoStack](https://github.com/nano-labs-io/nanostack-api) - Permissionless cross-chain execution API — 59 chains, 8-15 bps fees, real-time signal data with BLAKE3 proofs.
 * [Nomics API](https://p.nomics.com/cryptocurrency-bitcoin-api) - Trades and orders, market data, market cap.
 * [shrimpy developers](https://developers.shrimpy.io/) - Real-time full order book data, limit orders, open orders, smart order routing, exchange account management, user management, and a complete cloud infrastructure solution right out of the box.


### PR DESCRIPTION
### Summary
Adds [Horus Flow](https://github.com/horustechltd/horus-flow-mcp) under `## API and data providers`.

### Description
Horus Flow is an institutional-grade crypto orderflow engine and Model Context Protocol (MCP) server providing sub-second L2 orderbook imbalance, whale spoofing detection, and Level 4 Cortex cognitive market intelligence for automated trading bots (Freqtrade, CCXT) and AI agents. Free tier available.