### PR TITLE
Add crypto exchange fee calculator and webhook de-duplication demo (Miscellaneous tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Production-grade Rust-native trading engine with deterministic event-driven arch
 * [undervalued-crypto-finder](https://github.com/Erfaniaa/undervalued-crypto-finder) - Get a list of cryptocurrencies which are now cheap and may be a good opportunity for investment. This project finds some cryptocurrencies which are below the daily moving average (eg. MA200).
 * [Gunbot Quant](https://github.com/GuntharDeNiro/gunbot-quant) - Standalone application for market screening and backtesting, focus on screening with algo trading in mind, offers repeatable workflows and useful, beautiful reports.
 * [Wealthfolio](https://github.com/wealthfolio/wealthfolio) - A beautiful, private, local-first personal finance tracker. Investments, net worth, spending, and simulations.
+* [Crypto Exchange Fee Calculator](https://pddjf.com/tools/crypto-exchange-fee-calculator/) - Compares USDT-perpetual maker/taker fees across nine exchanges (Binance, OKX, Bybit, Bitget, MEXC, Gate, Kraken, KuCoin, HTX) from their public VIP ladders, with official sources, a downloadable JSON dataset and a dated change log.
+* [Webhook De-duplication and Risk Gate Demo](https://github.com/yfjelley/signalcraft-labs-engineering-notes/tree/master/demos/webhook-dedupe-risk-gate) - Dependency-free Node.js dry-run of TradingView-style webhook execution: event-id de-duplication, cooldown, pre-trade risk checks and audit logs.
 
 ## Development Communities
 ### Telegram


### PR DESCRIPTION
Two additions to **Miscellaneous tools**:

- **Crypto Exchange Fee Calculator** — https://pddjf.com/tools/crypto-exchange-fee-calculator/ — compares USDT-perpetual maker/taker fees across nine exchanges (Binance, OKX, Bybit, Bitget, MEXC, Gate, Kraken, KuCoin, HTX) using each exchange's public VIP ladder. Every rate links to the official fee page with the date it was checked; the underlying data is downloadable as JSON (https://pddjf.com/data/exchange-fees.json) and changes are logged with sources at https://pddjf.com/exchange-fee-changes/ (RSS available). Free, no account.
- **Webhook De-duplication and Risk Gate Demo** — https://github.com/yfjelley/signalcraft-labs-engineering-notes/tree/master/demos/webhook-dedupe-risk-gate — a dependency-free Node.js dry-run of the TradingView-style webhook execution path: stable event-id de-duplication, cooldown windows, pre-trade risk checks and audit-log output. MIT-style public repo, runnable with `node`.

Disclosure: I maintain both. Happy to adjust wording or placement.